### PR TITLE
Styling edits

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -7,7 +7,9 @@
       <router-link to="/login">
         <button class="login">Login</button>
       </router-link>
-      <button class="logout" @click="logout">Log Out</button>
+      <span v-if="this.loggedIn == true">
+        <button class="logout" @click="logout">Log Out</button>
+      </span>
     </nav>
     <div class="modal" ref="subscriptionModal">
       <!-- Modal content -->

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -11,78 +11,12 @@
         <button class="logout" @click="logout">Log Out</button>
       </span>
     </nav>
-    <div class="modal" ref="subscriptionModal">
+    <div class="modal" ref="modal">
       <!-- Modal content -->
-      <div class="modal-content" ref="subscriptionModalContent">
+      <div class="modal-content" ref="modalContent">
         <div class="modal-body">
-          <span @click="$refs.subscriptionModal.style.display='none'" class="close">&times;</span>
-          <p>You're subscribed to {{ this.podcastName }}</p>
-          <router-link to="/subscriptions">
-            <button class="button">Visit Subscriptions Page</button>
-          </router-link>
-        </div>
-      </div>
-    </div>
-    <div class="modal" ref="logoutModal">
-      <!-- Modal content -->
-      <div class="modal-content" ref="logoutModalContent">
-        <div class="modal-body">
-          <span @click="$refs.logoutModal.style.display='none'" class="close">&times;</span>
-          <p>You're logged out!</p>
-        </div>
-      </div>
-    </div>
-    <div class="modal" ref="registerModal">
-      <!-- Modal content -->
-      <div class="modal-content" ref="registerModalContent">
-        <div class="modal-body">
-          <span @click="$refs.registerModal.style.display='none'" class="close">&times;</span>
-          <p>Thanks for registering, {{ this.userInSession }}. You're logged in!</p>
-        </div>
-      </div>
-    </div>
-    <div class="modal" ref="loginModal">
-      <!-- Modal content -->
-      <div class="modal-content" ref="loginModalContent">
-        <div class="modal-body">
-          <span @click="$refs.loginModal.style.display='none'" class="close">&times;</span>
-          <p>You're logged in, {{ this.userInSession }}.</p>
-        </div>
-      </div>
-    </div>
-    <div class="modal" ref="createPlaylistModal">
-      <!-- Modal content -->
-      <div class="modal-content" ref="createPlaylistModalContent">
-        <div class="modal-body">
-          <span @click="$refs.createPlaylistModal.style.display='none'" class="close">&times;</span>
-          <p>Playlist created.</p>
-        </div>
-      </div>
-    </div>
-    <div class="modal" ref="addPlaylistItemModal">
-      <!-- Modal content -->
-      <div class="modal-content" ref="addPlaylistItemModalContent">
-        <div class="modal-body">
-          <span @click="$refs.addPlaylistItemModal.style.display='none'" class="close">&times;</span>
-          <p>Episode added to playlist.</p>
-        </div>
-      </div>
-    </div>
-    <div class="modal" ref="deletePlaylistModal">
-      <!-- Modal content -->
-      <div class="modal-content" ref="deletePlaylistModalContent">
-        <div class="modal-body">
-          <span @click="$refs.deletePlaylistModal.style.display='none'" class="close">&times;</span>
-          <p>Playlist deleted.</p>
-        </div>
-      </div>
-    </div>
-    <div class="modal" ref="removePlaylistItemModal">
-      <!-- Modal content -->
-      <div class="modal-content" ref="removePlaylistItemModalContent">
-        <div class="modal-body">
-          <span @click="$refs.removePlaylistItemModal.style.display='none'" class="close">&times;</span>
-          <p>Playlist episode removed.</p>
+          <span @click="$refs.modal.style.display='none'" class="close">&times;</span>
+          <p>{{this.modalText}}</p>
         </div>
       </div>
     </div>
@@ -153,7 +87,8 @@ export default {
       loggedIn: "",
       subscribedPodcastIds: [],
       userInSession: "",
-      activeClass: "active"
+      activeClass: "active",
+      modalText: ""
     };
   },
   methods: {
@@ -161,25 +96,27 @@ export default {
       axios.post("/subscription", { name, rss_feed_url, podcast_id });
       this.getSubscribedPodcastIds();
       this.podcastName = name;
-      this.openModal(
-        this.$refs.subscriptionModal,
-        this.$refs.subscriptionModalContent
-      );
+      this.modalText = "You've subscribed to " + this.podcastName;
+      this.openModal();
     },
     getSubscribedPodcastIds() {
       axios.post("/test-user-subscribed").then(res => {
         this.subscribedPodcastIds = res.data.podcast_ids;
       });
     },
-    openModal(modal, modalContent) {
+    openModal() {
+      let modal = this.$refs.modal;
+      let modalContent = this.$refs.modalContent;
       modal.style.display = "block";
       setTimeout(function() {
-        modalContent.classList.add("animate-up");
+        modalContent.classList.add("animate-down");
         modal.classList.add("fade-out");
       }, 3000);
       setTimeout(function() {
         modal.style.display = "none";
       }, 3400);
+      modal.classList.remove("animate-down");
+      modal.classList.remove("fade-out");
     },
     disableSubscribeButton(podcastId) {
       return this.subscribedPodcastIds.includes(podcastId);
@@ -225,7 +162,8 @@ export default {
     logout() {
       axios.post("/logout");
       this.loggedIn = false;
-      this.openModal(this.$refs.logoutModal, this.$refs.logoutModalContent);
+      this.modalText = "You've been logged out"
+      this.openModal();
     },
     async testUserInSession() {
       this.userInSession = this.userInSession;

--- a/client/src/assets/css/styles.css
+++ b/client/src/assets/css/styles.css
@@ -180,6 +180,11 @@ button.button:hover {
   animation-duration: 0.5s;
 }
 
+.animate-down {
+  animation-name: animatedown;
+  animation-duration: 0.5s;
+}
+
 @keyframes animatedown {
   from {
     top: -300px;

--- a/client/src/components/Login.vue
+++ b/client/src/components/Login.vue
@@ -48,7 +48,9 @@ export default {
           this.username = '';
           this.password = '';
           this.$parent.loggedIn = true;
-          this.$parent.openModal(this.$parent.$refs.loginModal, this.$parent.$refs.loginModalContent);
+          this.$parent.modalText = "Welcome back, " + this.$parent.userInSession;
+          this.$parent.openModal();
+          this.$router.push('/subscriptions');
         }
       });
     }

--- a/client/src/components/Login.vue
+++ b/client/src/components/Login.vue
@@ -1,20 +1,17 @@
 <template>
-  <div class="login-contents">
-    <div class="centered">
-      <div v-if="!this.$parent.loggedIn">
-      <!-- if there's not currently a user logged in, allow them to log in -->
-        <h1>Login</h1>
-        <p>Username:</p><input v-model="username" @keyup.enter="login()" type="text" />
-        <p>Password:</p><input type="password" v-model="password" @keyup.enter="login()"/>
-        <br><br>
-        <button @click="login()">Submit</button>
-        <div class="error">{{ error }}</div>
-      </div>
-      <div v-if="this.$parent.loggedIn"> 
-      <!-- if the user is already logged in, tell them -->
-        <h1>You're already logged in.</h1>
-      </div>
-    </div>
+  <div v-if="this.$parent.loggedIn"> 
+  <!-- if the user is already logged in, tell them -->
+    <h1>You're already logged in.</h1>
+  </div>
+  <div v-else class="login-contents">
+  <!-- if there's not currently a user logged in, allow them to log in -->
+    <h1>Login</h1>
+    <p>Username:</p>
+    <input v-model="username" @keyup.enter="login()" type="text" />
+    <p>Password:</p><input type="password" v-model="password" @keyup.enter="login()"/>
+    <br><br>
+    <button @click="login()">Submit</button>
+    <div class="error">{{ error }}</div>
   </div>
 </template>
 
@@ -61,10 +58,6 @@ export default {
 <style scoped>
 .login-contents {
   padding-top: 20px;
-  display: flex;
-}
-.centered {
-  justify-content: center;
 }
 .error {
   font-weight: bold;

--- a/client/src/components/Playlists.vue
+++ b/client/src/components/Playlists.vue
@@ -50,10 +50,8 @@ export default {
       axios
         .post("/playlists", { title: this.playlistTitle })
         .then(() => this.getAndSetUserPlaylists());
-      this.$parent.openModal(
-        this.$parent.$refs.createPlaylistModal,
-        this.$parent.$refs.createPlaylistModalContent
-      );
+      this.$parent.modalText = "Playlist created";
+      this.$parent.openModal();
     },
     updateIndex(index) {
       this.playlistID = index;
@@ -70,10 +68,6 @@ export default {
       axios
         .patch("/playlist_items", { playlist_item_id: playlist_item_id })
         .then(() => this.getAndSetUserPlaylists());
-      this.$parent.openModal(
-        this.$parent.$refs.removePlaylistItemModal,
-        this.$parent.$refs.removePlaylistItemModalContent
-      );
     },
     deletePlaylist(playlist_id) {
       for (let i = 0; i < this.userPlaylistItems.length; i++) {
@@ -83,13 +77,7 @@ export default {
       }
       axios
         .patch("/playlists", { playlist_id: playlist_id })
-        .then(
-          () => this.getAndSetUserPlaylists(),
-          this.$parent.openModal(
-            this.$parent.$refs.deletePlaylistModal,
-            this.$parent.$refs.deletePlaylistModalContent
-          )
-        );
+      this.getAndSetUserPlaylists();
     }
   },
   mounted() {

--- a/client/src/components/Podcast.vue
+++ b/client/src/components/Podcast.vue
@@ -82,10 +82,8 @@ export default {
       this.addingToPlaylist = true;
       let playlistID = this.event.target.value;
       axios.post("/playlist_items", { playlist_id: playlistID, episode_title: this.episodeTitle, episode_description: this.episodeDescription, episode_url: this.episodeUrl })
-      .then(() => {
-        // this.$router.push("/playlists");
-      })
-      this.$parent.openModal(this.$parent.$refs.addPlaylistItemModal, this.$parent.$refs.addPlaylistItemModalContent);
+      this.$parent.modalText = "Episode added to playlist"
+      this.$parent.openModal();
     },
     testDuplicateHistoryEntry() {
       // before adding a new user to DB, make sure that username isn't already taken

--- a/client/src/components/Podcast.vue
+++ b/client/src/components/Podcast.vue
@@ -167,7 +167,7 @@ export default {
           clearInterval(interval);
           this.trackPlaying = false;
         }
-      }, 5000)
+      }, 2000)
     }
   },
 

--- a/client/src/components/Podcast.vue
+++ b/client/src/components/Podcast.vue
@@ -33,9 +33,9 @@
       <audio controls id="podcast-audio" @play="testDuplicateHistoryEntry()" @pause="registerPause()">
         <source :src="musicFile" type="audio/mpeg" />
       </audio>
-      <button class="button" style="margin: 20px auto;" @click="getRSSFeed(this.$parent.podcastFeedURL)">
+      <!-- <button class="button" style="margin: 20px auto;" @click="getRSSFeed(this.$parent.podcastFeedURL)">
         Return to episodes
-      </button>
+      </button> -->
     </div>
   </div>
 </template>

--- a/client/src/components/Register.vue
+++ b/client/src/components/Register.vue
@@ -1,7 +1,11 @@
 <template>
-  <div class="register-component">
+  <div v-if="this.$parent.loggedIn"> 
+  <!-- if the user is already logged in, tell them -->
+    <h1>You're already logged in.</h1>
+  </div>
+  <div v-else class="register-component">
     <!-- if a user isn't currently logged in, allow them to register -->
-    <h1>Register</h1>
+    <h1>Register</h1><br>
     <p>Username:</p>
     <input v-model="username" type="text" @keyup.enter="testDuplicateUser()" />
     <p>Password:</p>

--- a/client/src/components/Register.vue
+++ b/client/src/components/Register.vue
@@ -94,7 +94,9 @@ export default {
       this.username = "";
       this.password = "";
       this.confirmPassword = "";
-      this.$parent.openModal(this.$parent.$refs.registerModal, this.$parent.$refs.registerModalContent);
+      this.$parent.modalText = "Thank you for registering, " + this.$parent.userInSession;
+      this.$parent.openModal();
+      this.$router.push('/browse');
     }
   }
 };


### PR DESCRIPTION
Users are rerouted to their subscriptions page after logging in
Users are rerouted to the browse page after registering
Modal window staggering is fixed, and there's now only one generic modal window pattern being used with different messages for each 'event'
Styling on the login and register page are consistent - for some reason h1  tags weren't being centered on login but they were on register
the Return to Episodes button is commented out
the async function determining playback place is being run every 2 seconds now for the sake of the presentation